### PR TITLE
feat(fix-userDTOMapper): se le agrega a la respuesta del userDTO el atributo isEliminado

### DIFF
--- a/src/main/java/com/finnegans/gestioncrisalis/dtos/mappers/UsuarioDTOMapper.java
+++ b/src/main/java/com/finnegans/gestioncrisalis/dtos/mappers/UsuarioDTOMapper.java
@@ -17,6 +17,6 @@ public class UsuarioDTOMapper {
     public UsuarioResponseDTO build(){
         if (usuario == null) throw new RuntimeException("Debe pasar la entidad Usuario");
 
-        return new UsuarioResponseDTO(usuario.getId(), usuario.getUsuario());
+        return new UsuarioResponseDTO(usuario.getId(), usuario.getUsuario(), usuario.isEliminado());
     }
 }

--- a/src/main/java/com/finnegans/gestioncrisalis/dtos/request/UsuarioResponseDTO.java
+++ b/src/main/java/com/finnegans/gestioncrisalis/dtos/request/UsuarioResponseDTO.java
@@ -12,4 +12,7 @@ public class UsuarioResponseDTO {
 
     @JsonProperty("usuario")
     private String usuarioDTO;
+
+    @JsonProperty("eliminado")
+    private boolean eliminadoDTO;
 }


### PR DESCRIPTION
Viendo la planificación de la tabla de usuarios vi que faltaba en la respuesta el atributo que responde al método PATCH y marcaría si esta activo o no el usuario, lo hice siguiendo la norma marcada de antemano. Primero modifique el UsuarioResponseDTO para agregar el atributo en la respuesta y luego  usarlo en el constructor en UsuarioDTOMapper
![image](https://github.com/CrisalisVerde2023/gestion-crisalis/assets/104619744/342bb525-5ba6-49bc-935c-c93535fc613b)
![image](https://github.com/CrisalisVerde2023/gestion-crisalis/assets/104619744/319233b5-1f69-47d3-a878-e66fcb029a0c)
![image](https://github.com/CrisalisVerde2023/gestion-crisalis/assets/104619744/7af372bb-5d6f-4ca2-a3b6-3b6c72acbff2)
