### PR TITLE
DNI duplicado y de exactamente 8 caracteres corregido

### DIFF
--- a/src/main/java/com/finnegans/gestioncrisalis/exceptions/custom/DuplicateDniException.java
+++ b/src/main/java/com/finnegans/gestioncrisalis/exceptions/custom/DuplicateDniException.java
@@ -1,0 +1,15 @@
+package com.finnegans.gestioncrisalis.exceptions.custom;
+
+public class DuplicateDniException extends RuntimeException {
+    public DuplicateDniException(){
+        super("Ya existe una persona con el mismo DNI");
+    }
+
+    public DuplicateDniException(String message) {
+        super(message);
+    }
+
+    public DuplicateDniException(String message, Throwable cause){
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/finnegans/gestioncrisalis/exceptions/custom/InvalidDniException.java
+++ b/src/main/java/com/finnegans/gestioncrisalis/exceptions/custom/InvalidDniException.java
@@ -1,0 +1,7 @@
+package com.finnegans.gestioncrisalis.exceptions.custom;
+
+public class InvalidDniException extends RuntimeException {
+    public InvalidDniException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/finnegans/gestioncrisalis/models/Persona.java
+++ b/src/main/java/com/finnegans/gestioncrisalis/models/Persona.java
@@ -29,7 +29,7 @@ public class Persona {
     @Column(name = "APELLIDO", nullable = false)
     private String apellido;
 
-    @Column(name = "DNI", nullable = false)
+    @Column(name = "DNI", nullable = false, unique = true)
     private String dni;
 
     @Column(name = "FECHA_CREACION", nullable = false)

--- a/src/main/java/com/finnegans/gestioncrisalis/repositories/PersonaRepository.java
+++ b/src/main/java/com/finnegans/gestioncrisalis/repositories/PersonaRepository.java
@@ -4,7 +4,10 @@ import com.finnegans.gestioncrisalis.models.Persona;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PersonaRepository extends JpaRepository<Persona, Long> {
+    Optional<Persona> findByDni(String dni);
 
 }

--- a/src/main/java/com/finnegans/gestioncrisalis/services/impl/PersonaServiceImpl.java
+++ b/src/main/java/com/finnegans/gestioncrisalis/services/impl/PersonaServiceImpl.java
@@ -2,6 +2,8 @@ package com.finnegans.gestioncrisalis.services.impl;
 
 import com.finnegans.gestioncrisalis.dtos.mappers.PersonaDTOMapper;
 import com.finnegans.gestioncrisalis.dtos.PersonaDTO;
+import com.finnegans.gestioncrisalis.exceptions.custom.DuplicateDniException;
+import com.finnegans.gestioncrisalis.exceptions.custom.InvalidDniException;
 import com.finnegans.gestioncrisalis.exceptions.custom.ResourceNotFound;
 import com.finnegans.gestioncrisalis.models.Persona;
 import com.finnegans.gestioncrisalis.repositories.PersonaRepository;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -25,10 +28,24 @@ public class PersonaServiceImpl implements PersonaService {
 
     @Override
     public Persona save(PersonaDTO personaDTO) {
+        Optional<Persona> existingPersona = personaRepository.findByDni(personaDTO.getDniDTO());
+
+        if (existingPersona.isPresent()){
+            throw new DuplicateDniException("Ya existe una persona con el mismo DNI");
+        }
+
+        String dni = personaDTO.getDniDTO();
+
+        if (dni.length() != 8) {
+            throw new InvalidDniException("El DNI debe tener 8 caracteres");
+        }
+
         Persona persona = new Persona();
         persona.setNombre(personaDTO.getNombreDTO());
         persona.setApellido(personaDTO.getApellidoDTO());
         persona.setDni(personaDTO.getDniDTO());
+
+
 
         return this.personaRepository.save(persona);
     }


### PR DESCRIPTION
Corregido, ahora no permite guardar DNI duplicado y lo guarda solo cuando la longitud es exactamente de 8 caracteres